### PR TITLE
Combined dependency updates (2023-08-02)

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -31,7 +31,7 @@
 			<dependency>
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-classic</artifactId>
-				<version>1.2.12</version>
+				<version>1.4.8</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -42,7 +42,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-source-plugin</artifactId>
-					<version>3.2.1</version>
+					<version>3.3.0</version>
 					<executions>
 						<execution>
 							<id>attach-sources</id>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -26,7 +26,7 @@
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
-				<version>1.7.36</version>
+				<version>2.0.7</version>
 			</dependency>
 			<dependency>
 				<groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Includes these updates:
- [Bump ch.qos.logback:logback-classic from 1.2.12 to 1.4.8 in /test](https://github.com/javiertuya/branch-snapshots-action/pull/3)
- [Bump org.apache.maven.plugins:maven-source-plugin from 3.2.1 to 3.3.0 in /test](https://github.com/javiertuya/branch-snapshots-action/pull/2)
- [Bump org.slf4j:slf4j-api from 1.7.36 to 2.0.7 in /test](https://github.com/javiertuya/branch-snapshots-action/pull/1)