### PR TITLE
Combined dependency updates (2023-10-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         working-directory: test
     #if: ${{ false }}  # disable for now
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
           exit 1
         
       - name: Checkout GitHub repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Select Java Version
         uses: actions/setup-java@v3

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -55,7 +55,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.5.0</version>
+					<version>3.6.0</version>
 					<configuration>
 						<quiet>true</quiet>
 						<doclint>none</doclint>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -26,7 +26,7 @@
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
-				<version>2.0.7</version>
+				<version>2.0.9</version>
 			</dependency>
 			<dependency>
 				<groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Includes these updates:
- [Bump actions/checkout from 3 to 4](https://github.com/javiertuya/branch-snapshots-action/pull/7)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.5.0 to 3.6.0 in /test](https://github.com/javiertuya/branch-snapshots-action/pull/8)
- [Bump org.slf4j:slf4j-api from 2.0.7 to 2.0.9 in /test](https://github.com/javiertuya/branch-snapshots-action/pull/9)