### PR TITLE
Combined dependency updates (2024-01-03)

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -55,7 +55,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.6.2</version>
+					<version>3.6.3</version>
 					<configuration>
 						<quiet>true</quiet>
 						<doclint>none</doclint>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -26,7 +26,7 @@
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
-				<version>2.0.9</version>
+				<version>2.0.10</version>
 			</dependency>
 			<dependency>
 				<groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Includes these updates:
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.6.2 to 3.6.3 in /test](https://github.com/javiertuya/branch-snapshots-action/pull/17)
- [Bump org.slf4j:slf4j-api from 2.0.9 to 2.0.10 in /test](https://github.com/javiertuya/branch-snapshots-action/pull/18)