### PR TITLE
Combined dependency updates (2024-09-02)

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -31,7 +31,7 @@
 			<dependency>
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-classic</artifactId>
-				<version>1.5.6</version>
+				<version>1.5.7</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump ch.qos.logback:logback-classic from 1.5.6 to 1.5.7 in /test](https://github.com/javiertuya/branch-snapshots-action/pull/35)
- [Bump org.slf4j:slf4j-api from 2.0.13 to 2.0.16 in /test](https://github.com/javiertuya/branch-snapshots-action/pull/34)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.8.0 to 3.10.0 in /test](https://github.com/javiertuya/branch-snapshots-action/pull/33)