### PR TITLE
Combined dependency updates (2024-11-02)

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -31,7 +31,7 @@
 			<dependency>
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-classic</artifactId>
-				<version>1.5.8</version>
+				<version>1.5.12</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump ch.qos.logback:logback-classic from 1.5.8 to 1.5.12 in /test](https://github.com/javiertuya/branch-snapshots-action/pull/39)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.10.0 to 3.10.1 in /test](https://github.com/javiertuya/branch-snapshots-action/pull/38)