### PR TITLE
Combined dependency updates (2025-01-11)

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -55,7 +55,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.11.1</version>
+					<version>3.11.2</version>
 					<configuration>
 						<quiet>true</quiet>
 						<doclint>none</doclint>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.11.1 to 3.11.2 in /test](https://github.com/javiertuya/branch-snapshots-action/pull/44)
- [Bump ch.qos.logback:logback-classic from 1.5.12 to 1.5.15 in /test](https://github.com/javiertuya/branch-snapshots-action/pull/43)