### PR TITLE
Combined dependency updates (2025-09-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Select Java Version
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '8'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         working-directory: test
     #if: ${{ false }}  # disable for now
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Select Java Version
         uses: actions/setup-java@v5
         with:

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
           exit 1
         
       - name: Checkout GitHub repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Select Java Version
         uses: actions/setup-java@v5

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ runs:
         uses: actions/checkout@v4
 
       - name: Select Java Version
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ inputs.java-version }}

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -55,7 +55,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.11.2</version>
+					<version>3.11.3</version>
 					<configuration>
 						<quiet>true</quiet>
 						<doclint>none</doclint>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump actions/setup-java from 4 to 5](https://github.com/javiertuya/branch-snapshots-action/pull/53)
- [Bump actions/checkout from 4 to 5](https://github.com/javiertuya/branch-snapshots-action/pull/54)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.11.2 to 3.11.3 in /test](https://github.com/javiertuya/branch-snapshots-action/pull/55)