### PR TITLE
Combined dependency updates (2025-10-04)

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -55,7 +55,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.11.3</version>
+					<version>3.12.0</version>
 					<configuration>
 						<quiet>true</quiet>
 						<doclint>none</doclint>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.11.3 to 3.12.0 in /test](https://github.com/javiertuya/branch-snapshots-action/pull/58)
- [Bump ch.qos.logback:logback-classic from 1.5.18 to 1.5.19 in /test](https://github.com/javiertuya/branch-snapshots-action/pull/57)