### PR TITLE
Combined dependency updates (2026-07-04)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         working-directory: test
     #if: ${{ false }}  # disable for now
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Select Java Version
         uses: actions/setup-java@v5
         with:
@@ -35,7 +35,7 @@ jobs:
         working-directory: delete-snapshots
     #if: ${{ false }}  # disable for now
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Test nodejs delete snapshots
         run: npm install && npm test
@@ -53,7 +53,7 @@ jobs:
       run:
         working-directory: test
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       #- uses: javiertuya/branch-snapshots-action@v1.1.0
       - uses: ./
         with: 

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
           exit 1
         
       - name: Checkout GitHub repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Select Java Version
         uses: actions/setup-java@v5

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -31,7 +31,7 @@
 			<dependency>
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-classic</artifactId>
-				<version>1.5.33</version>
+				<version>1.5.37</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump actions/checkout from 6 to 7](https://github.com/javiertuya/branch-snapshots-action/pull/78)
- [Bump ch.qos.logback:logback-classic from 1.5.33 to 1.5.37 in /test](https://github.com/javiertuya/branch-snapshots-action/pull/77)